### PR TITLE
Format metrics and train modules

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,3 +42,6 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.pytest.ini_options]
 addopts = "-q --maxfail=1 --disable-warnings --cov=src"
+
+[tool.isort]
+profile = "black"

--- a/src/models/metrics.py
+++ b/src/models/metrics.py
@@ -1,7 +1,12 @@
 from __future__ import annotations
 
-from sklearn.metrics import (average_precision_score, brier_score_loss,
-                             f1_score, log_loss, roc_auc_score)
+from sklearn.metrics import (
+    average_precision_score,
+    brier_score_loss,
+    f1_score,
+    log_loss,
+    roc_auc_score,
+)
 
 
 def compute_metrics(y_true, proba, threshold: float = 0.5):

--- a/src/models/train.py
+++ b/src/models/train.py
@@ -13,11 +13,10 @@ from lightgbm import LGBMClassifier
 from sklearn.pipeline import Pipeline
 from xgboost import XGBClassifier
 
+from src import settings
 from src.data.features import make_preprocess
 from src.models.calibrate import calibrate
 from src.models.metrics import compute_metrics
-from src.settings import (MLFLOW_EXPERIMENT_NAME, MLFLOW_TRACKING_URI,
-                          MODELS_DIR)
 
 
 def _load_xy(
@@ -48,8 +47,8 @@ def _build_estimator(cfg) -> Pipeline:
 
 
 def main() -> None:
-    mlflow.set_tracking_uri(MLFLOW_TRACKING_URI)
-    mlflow.set_experiment(MLFLOW_EXPERIMENT_NAME)
+    mlflow.set_tracking_uri(settings.MLFLOW_TRACKING_URI)
+    mlflow.set_experiment(settings.MLFLOW_EXPERIMENT_NAME)
 
     with initialize(version_base=None, config_path="../../configs"):
         cfg = compose(config_name="config")
@@ -73,7 +72,7 @@ def main() -> None:
         mlflow.log_params(dict(cfg.model.params))
         mlflow.log_param("model_type", cfg.model.type)
 
-        models_dir = Path(MODELS_DIR)
+        models_dir = Path(settings.MODELS_DIR)
         models_dir.mkdir(parents=True, exist_ok=True)
         model_path = models_dir / run.info.run_id
         mlflow.sklearn.save_model(estimator, model_path)


### PR DESCRIPTION
## Summary
- reformat sklearn metrics import to match black formatting
- update the training module to import the settings package and reference constants via the module to keep lines short
- configure isort to use the black profile so the pre-commit formatting hooks agree

## Testing
- poetry run black --check .
- poetry run pre-commit run --all-files

------
